### PR TITLE
Navigator/Titles behaviour fixes

### DIFF
--- a/js/components/Header.js
+++ b/js/components/Header.js
@@ -16,19 +16,23 @@ const Header = React.createClass ({
     return {
       index: 0,
       title: 'Good Question',
+      path: 'none'
     }
   },
 
-  componentWillReceiveProps(next_props) {
-    let state = Object.assign({}, this.state);
-    if (next_props.navState) {
-      const position = next_props.navState.routeStack.length - 1
-      state.index = position;
-      this.setState(state);
-    }
-    if (next_props.title) {
-      state.title = next_props.title;
-      this.setState(state);
+  componentWillReceiveProps(nextProps) {
+    console.log(nextProps)
+    try {
+      let position = nextProps.navState.routeStack.length - 1
+      let nextTitle = nextProps.navState.routeStack[nextProps.navState.routeStack.length-1].title
+      if (nextTitle && nextTitle !== this.state.title) {
+        this.setState({
+          title: nextTitle,
+          index: position,
+        })
+      }
+    } catch(e) {
+      console.warn(e)
     }
   },
 

--- a/js/components/Header.js
+++ b/js/components/Header.js
@@ -21,7 +21,6 @@ const Header = React.createClass ({
   },
 
   componentWillReceiveProps(nextProps) {
-    console.log(nextProps)
     try {
       let position = nextProps.navState.routeStack.length - 1
       let nextTitle = nextProps.navState.routeStack[nextProps.navState.routeStack.length-1].title

--- a/js/router/SharedNavigator.js
+++ b/js/router/SharedNavigator.js
@@ -75,33 +75,33 @@ const SharedNavigator = React.createClass ({
       self.setState(state);
     });
   },
-  setTitle(title) {
-    let state = Object.assign({}, this.state);
-    state.title = title;
-    this.setState(state);
-  },
+
+  /* Methods */
   setAuthenticated(authenticated) {
     let state = Object.assign({}, this.state);
     state.isAuthenticated = authenticated;
     this.setState(state);
   },
+
+  /* Render */
   routeMapper(route, nav) {
     // we secure all routes
     if (!this.state.isAuthenticated) {
-      return <LoginPage navigator={nav} setTitle={this.setTitle} setAuthenticated={this.setAuthenticated} />
+      route.path = 'login'
+      route.title = 'Good Question'
     }
-    switch (route.name) {
-      case 'login': return <LoginPage navigator={nav} setTitle={this.setTitle} setAuthenticated={this.setAuthenticated} />
-      case 'surveylist': return <SurveyListPage navigator={nav} setTitle={this.setTitle} />
-      case 'terms': return <TermsOfServicePage navigator={nav} setTitle={this.setTitle} />
-      case 'registration1': return <RegistrationPagePart1 navigator={nav} setTitle={this.setTitle} />
-      case 'registration2': return <RegistrationPagePart2 navigator={nav} setTitle={this.setTitle} />
-      case 'form': return <FormPage navigator={nav} form={route.form} survey={route.survey} setTitle={this.setTitle} />
-      default: return <SurveyListPage navigator={nav} setTitle={this.setTitle} />
+    switch (route.path) {
+      case 'login': return <LoginPage navigator={nav} setAuthenticated={this.setAuthenticated} />
+      case 'surveylist': return <SurveyListPage navigator={nav} />
+      case 'terms': return <TermsOfServicePage navigator={nav} />
+      case 'registration1': return <RegistrationPagePart1 navigator={nav} />
+      case 'registration2': return <RegistrationPagePart2 navigator={nav} />
+      case 'form': return <FormPage navigator={nav} form={route.form} survey={route.survey} />
+      default: return <SurveyListPage navigator={nav} />
     }
   },
   render() {
-    const initialRoute = {name: 'surveylist'}
+    const initialRoute = { path: 'surveylist', title: 'Surveys' }
     // show loading component without the navigationBar
     if (this.state.isLoading) {
       return (<Loading/>);

--- a/js/views/FormPage.js
+++ b/js/views/FormPage.js
@@ -42,7 +42,6 @@ const FormPage = React.createClass ({
   },
 
   componentWillMount() {
-    this.props.setTitle("Survey: " + this.props.survey.get('title'));
     let id = this.genSubmissionKey();
     AsyncStorage.getItem(id, (err, res) => {
       if (res) {
@@ -90,7 +89,7 @@ const FormPage = React.createClass ({
       date: new Date(),
       answers: this.state.answers,
     })).then(()=>{
-      this.props.navigator.push({name: 'surveyList'});
+      this.props.navigator.push({path: 'surveyList', title: 'Surveys'});
     }).catch((error)=>{
       console.error(error);
     });

--- a/js/views/LoginPage.js
+++ b/js/views/LoginPage.js
@@ -32,10 +32,6 @@ const LoginPage = React.createClass ({
     password: Joi.string().regex(/^([a-zA-Z0-9@*#]{8,15})$/).required().label('Password'),
   },
 
-  componentWillMount() {
-    this.props.setTitle(this.title);
-  },
-
   getInitialState() {
     return {
       username: '',

--- a/js/views/RegistrationPagePart1.js
+++ b/js/views/RegistrationPagePart1.js
@@ -24,11 +24,11 @@ const RegistrationPagePart1 = React.createClass ({
 
   /* Methods */
   goToTermsPage() {
-    this.props.navigator.push({name: 'terms'})
+    this.props.navigator.push({path: 'terms', title: 'Terms of Service'})
   },
 
   goToNextPage() {
-    this.props.navigator.push({name: 'registration2'})
+    this.props.navigator.push({path: 'registration2', title: 'Register'})
   },
 
   /* Render */

--- a/js/views/SurveyListPage.js
+++ b/js/views/SurveyListPage.js
@@ -29,7 +29,6 @@ const SurveyListPage = React.createClass ({
   },
 
   componentDidMount() {
-    this.props.setTitle(this.title);
     this.setState({
       dataSource: this.state.dataSource.cloneWithRows(this.state.list),
     });
@@ -82,7 +81,8 @@ const SurveyListPage = React.createClass ({
       alert('Error: Unable to fetch the Forms associated with this Survey.')
     } else {
       this.props.navigator.push({
-        name: 'form',
+        path: 'form',
+        title: 'Survey: ' + survey.get('title'),
         form: forms[0],
         survey: survey
       })


### PR DESCRIPTION
Fixes various bugs caused by navigation and titles.

The most notable change is the way routes are being handled by the navigator now. Titles are set in the route itself so we don't lose functionality when using the Header back button or Android's hardware 'Back' key.

The current approach also made using the navigator object being passed to the view components almost impossible, as title changes would not match for components that were already mounted.

New format for routes:
`{path: 'surveyList', title: 'Surveys'}
- path being the old 'name' variable, changed for clarity
- title being the title to be displayed in the Header
- The recent setTile function has been removed from our view components as a result
