### PR TITLE
Send title to navigator on control panel item press

### DIFF
--- a/js/views/ControlPanel.js
+++ b/js/views/ControlPanel.js
@@ -19,7 +19,7 @@ export default React.createClass({
         />
         <ControlPanelItem
           onPress={()=>{
-            this.props.navigator.push({name: 'surveylist'})
+            this.props.navigator.push({name: 'surveylist', title: "Surveys"})
             this.props.closeDrawer()
           }}
           text="Surveys"


### PR DESCRIPTION
This is my first dive into the React code.
I discovered the bug occurred when opening the menu, selecting Surveys, navigating to a survey, then upon navigating back to the list with the back button, the title did not update to "Surveys". 
Looks like the `onPress` event in `controlPanelItem` clears the title if its not explicitly passed.
PT Bug: https://www.pivotaltracker.com/story/show/119815277
