### PR TITLE
use the default threshold

### DIFF
--- a/js/views/RegistrationPages.js
+++ b/js/views/RegistrationPages.js
@@ -177,8 +177,7 @@ const RegistrationPages = React.createClass ({
           index={this.state.index}
           beforePageChange={this.beforePageChange}
           onPageChange={this.onPageChange}
-          children={this.getChildren()}
-          threshold={75}>
+          children={this.getChildren()}>
         </Swiper>
       </View>
     )

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "react-native-vector-icons": "1.3.4",
     "realm": "^0.12.0",
     "react-native-drawer": "^2.2.2",
-    "react-native-page-swiper": "https://github.com/dan-nyanko/react-native-page-swiper#master"
   },
   "devDependencies": {
     "commander": "^2.9.0"


### PR DESCRIPTION
Note: to test your local node_modules/react-native-page-swiper directory will need deleted and reinstalled

Updated https://github.com/dan-nyanko/react-native-page-swiper to determine shouldContinue during the calculation of the relative distance of the gesture.  This will avoid the case of triggering form validation on short horizontal gesture movements.  

`rm -fr node_modules/react-native-page-swiper`
`npm install`

Test:
-Logout
-Click 'Register an Account'
-Swipe horizontal in small increments until the validation is triggered in beforePageChange
