### PR TITLE
Update index position even when title is empty

### DIFF
--- a/js/components/Header.js
+++ b/js/components/Header.js
@@ -26,14 +26,16 @@ const Header = React.createClass ({
 
   componentWillReceiveProps(nextProps) {
     try {
+      let title = this.state.title
       let position = nextProps.navState.routeStack.length - 1
       let nextTitle = nextProps.navState.routeStack[nextProps.navState.routeStack.length-1].title
-      if (nextTitle && nextTitle !== this.state.title) {
-        this.setState({
-          title: nextTitle,
-          index: position,
-        })
+      if (nextTitle && nextTitle !== title) {
+        title = nextTitle
       }
+      this.setState({
+        title: title,
+        index: position
+      })
     } catch(e) {
       console.warn(e)
     }


### PR DESCRIPTION
So this fixes the [bug](https://www.pivotaltracker.com/story/show/119786697) but introduces another: Since the registration has its own indexing, independent of the navigator's, the back button on the registration views takes the user back to the login instead of back to the previous registration view.

I'm not sure there is an easy fix. I played around a little but didn't get too far. I suppose we will somehow need to push an index into the navigator's routeStack? Seems outside of the scope of my React skills at this point.
