### PR TITLE
Truncate long titles and rework header styles

### DIFF
--- a/js/components/Header.js
+++ b/js/components/Header.js
@@ -48,7 +48,7 @@ const Header = React.createClass ({
     return (
       <View style={Styles.header.navBarRightButton}>
         <TouchableWithoutFeedback onPress={this.props.openDrawer}>
-          <Icon name="bars" size={30} color="#FFFFFF" />
+          <Icon name="bars" size={25} color="#FFFFFF" />
         </TouchableWithoutFeedback>
       </View>
     );
@@ -79,17 +79,17 @@ const Header = React.createClass ({
   render() {
     return (
       <View style={Styles.header.navBar}>
-        {
+        <View style={Styles.header.navBarLeftButton}>
+          {
           this.state.index > 0 ?
-          <View style={Styles.header.navBarLeftButton}>
-            <TouchableWithoutFeedback onPress={this.navigateBack}>
-              <Icon name="chevron-left" size={30} color="#FFFFFF" />
-            </TouchableWithoutFeedback>
-          </View>
+          <TouchableWithoutFeedback onPress={this.navigateBack}>
+            <Icon name="chevron-left" size={20} color="#FFFFFF" />
+          </TouchableWithoutFeedback>
           : null
-        }
-        <View>
-          <Text>
+          }
+        </View>
+        <View style={Styles.header.navBarTitle}>
+          <Text numberOfLines={1} style={Styles.header.navBarTitleText}>
             {this.state.title}
           </Text>
         </View>

--- a/js/styles/Variables.js
+++ b/js/styles/Variables.js
@@ -1,7 +1,7 @@
 import { Platform } from 'react-native'
 
 const Variables = {
-  HEADER_SIZE: 80,
+  HEADER_SIZE: 70,
   HEADER_PADDING: 20,
   REGISTRATION_HEIGHT: 125,
   PROFILE_HEIGHT: 250,

--- a/js/styles/_HeaderStyles.js
+++ b/js/styles/_HeaderStyles.js
@@ -6,7 +6,9 @@ import Variables from './Variables'
 const HeaderStyles = StyleSheet.create({
   navBar: {
     flex: 1,
-    justifyContent: 'center',
+    flexDirection: 'row',
+    flexWrap: 'nowrap',
+    justifyContent: 'space-between',
     alignItems: 'center',
     position: 'absolute',
     top: 0,
@@ -16,29 +18,21 @@ const HeaderStyles = StyleSheet.create({
     paddingTop: Variables.HEADER_PADDING,
     backgroundColor: Color.background1,
   },
-  navBarText: {
-    color: Color.background2,
-    fontSize: 16,
-    marginVertical: 10,
+  navBarTitle: {
+    flex: .8,
+    marginRight: 10,
   },
   navBarTitleText: {
-    color: Color.background2,
-    fontWeight: '500',
-    marginVertical: 9,
+    paddingRight: 10,
+    textAlign: 'center',
   },
   navBarLeftButton: {
-    flex: 1,
-    position: 'absolute',
-    left: 10,
-    top: 16 + Variables.HEADER_PADDING,
-    paddingLeft: 10,
+    flex: .1,
+    marginLeft: Variables.HEADER_PADDING,
   },
   navBarRightButton: {
-    flex: 1,
-    position: 'absolute',
-    paddingRight: 10,
-    right: 10,
-    top: 16 + Variables.HEADER_PADDING,
+    flex: .1,
+    marginRight: Variables.HEADER_PADDING - 10,
   },
 })
 


### PR DESCRIPTION
I reworked the styles of the header a bit. 
In order to take advantage of the flex box layout we need to always show the back button's container so it takes up the space and does not shift the title.
I noticed some of the spacing seems odd. Maybe there is space added around the icons?

PT Bug: https://www.pivotaltracker.com/story/show/120194835
