### PR TITLE
Remove Android BG geolocation import

### DIFF
--- a/js/api/BackgroundProcess.js
+++ b/js/api/BackgroundProcess.js
@@ -4,9 +4,7 @@ import Settings from '../settings'
 import { addSchedule } from './Schedule'
 import { checkTimeTriggers } from './Triggers'
 
-export const BackgroundGeolocation = Platform.OS === 'android' ?
-    require('react-native-background-geolocation') :
-    require('react-native-background-geolocation-android')
+export const BackgroundGeolocation = require('react-native-background-geolocation')
 
 let startTimer = Date.now()
 


### PR DESCRIPTION
The `require('react-native-background-geolocation-android')` import causes an error for me because I can't install the package. This happens when I'm testing on iOS. At first I thought it was because the ternary operator had its arguments reversed, but even when I swapped them, the error persisted, so now I think the react packager may be hoisting all the require calls. Since we're just targeting iOS for now I suggest only including the `require('react-native-background-geolocation')` import.
