### PR TITLE
Validate required questions and set default answers

### DIFF
--- a/js/api/Questions.js
+++ b/js/api/Questions.js
@@ -17,6 +17,7 @@ export function cacheParseQuestions(questions, formId) {
             order: questions[i].get('order'),
             text: questions[i].get('text'),
             type: questions[i].get('type'),
+            required: questions[i].get('required'),
             properties: JSON.stringify(questions[i].get('properties')),
           }, true)
         }

--- a/js/api/Surveys.js
+++ b/js/api/Surveys.js
@@ -115,5 +115,5 @@ function clearSurveyCache(exclusions) {
     })
   } catch (e) {
     console.error(e)
-  } 
+  }
 }

--- a/js/data/Realm.js
+++ b/js/data/Realm.js
@@ -17,7 +17,7 @@ const realmInstance = new Realm({
     TimeTrigger,
     Submission,
   ],
-  schemaVersion: 26,
+  schemaVersion: 27,
 })
 
 // Erases the current cache of a target object
@@ -45,7 +45,7 @@ export function clearRealmCache(objectName, idExclusions) {
     })
   } catch (e) {
     console.error(e)
-  } 
+  }
 }
 
 export default realmInstance;

--- a/js/models/Question.js
+++ b/js/models/Question.js
@@ -9,6 +9,7 @@ Question.schema = {
   	order: 'int',
     text: 'string',
     type: 'string',
+    required: 'bool',
     properties: 'string',
   }
 }


### PR DESCRIPTION
This prevents users from advancing past a required question until it is filled out and it sets the initial answer values. The initial answer values need to be set because the question UIs show default values but those default values are not saved.
