### PR TITLE
Fixes bug with colors prop in custom swiper

### DIFF
--- a/js/components/Swiper/Swiper.js
+++ b/js/components/Swiper/Swiper.js
@@ -145,6 +145,7 @@ export default class Swiper extends Component {
         style={this.props.dotContainerStyle}
         dotStyle={ this.props.dotStyle }
         activeDotStyle={ this.props.activeDotStyle }
+        activeColor={ this.props.activeDotColor }
       />
     }
   }

--- a/js/components/Swiper/dots.js
+++ b/js/components/Swiper/dots.js
@@ -15,6 +15,7 @@ export default class Dots extends Component {
     style: View.propTypes.style,
     dotStyle: View.propTypes.style,
     activeDotStyle: View.propTypes.style,
+    activeColor: React.PropTypes.string,
   };
 
   static defaultProps = {


### PR DESCRIPTION
Story:
https://www.pivotaltracker.com/story/show/120839031
- Color prop was being ignored in the new swiper, causing old
  components that used it to not have an “active dot” on their pagination.
