### PR TITLE
Do not add useMasterKey to Roles object on save

### DIFF
--- a/tool-populate/api/Roles.js
+++ b/tool-populate/api/Roles.js
@@ -12,7 +12,7 @@ function loadRoles (options, callback) {
 function createRole(roleToCreate) {
   var acl= new Parse.ACL()
   var role = new Parse.Role(roleToCreate, acl)
-  return role.save(useMasterKey)
+  return role.save(null, useMasterKey)
     .then(function(role){
       console.log(colors.green('Created role "' + roleToCreate + '"'))
     })


### PR DESCRIPTION
I noticed a `useMasterKey` property was being added to Roles. Removed it. 
This also seems to fix a bug I was noticing were the initial survey only contained 1 form (not sure if its related).
