### PR TITLE
added feature for working offline

### DIFF
--- a/js/api/Roles.js
+++ b/js/api/Roles.js
@@ -1,0 +1,28 @@
+import Parse from 'parse/react-native';
+
+// store the value in memory
+let _adminRole = null;
+
+/**
+ * returns the adminRole from the remote
+ */
+export function adminRole(done) {
+  if (_adminRole !== null) {
+    return done(null, _adminRole);
+  }
+  const query = new Parse.Query(Parse.Role);
+  query.equalTo('name', 'admin');
+  query.find(
+    (roles) => {
+      if (roles === null || roles.length <= 0) {
+        return done(null, 'admin');
+      }
+      _adminRole = roles[0];
+      done(null, _adminRole);
+    },
+    () => {
+      // Parse will accept Parse.Role or the string, fallback to the string
+      done(null, 'admin');
+    }
+  );
+}

--- a/js/api/Submissions.js
+++ b/js/api/Submissions.js
@@ -1,10 +1,35 @@
 import Parse from 'parse/react-native';
 import realm from '../data/Realm';
 import {currentUser} from '../api/Account';
+import { adminRole } from '../api/Roles';
 import crypto from 'crypto-js';
 import async from 'async';
+import _ from 'lodash';
 
 const Submission = Parse.Object.extend('Submission');
+/**
+ * create a submission Object with acl assigned
+ *
+ * @param {string} id, the unique id for the realm record
+ * @param {string} formId, the unique id for the parse form record
+ * @param {object} answers, the answers to the current form
+ * @param {object} user, the current parse user saved to AsyncStorage
+ * @param {object} role, the adminRole to be assigned to the object
+ */
+Submission.create = function create(uniqueId, formId, answers, user, role) {
+  const submission = new Submission();
+  submission.set('uniqueId', uniqueId);
+  submission.set('formId', formId);
+  submission.set('answers', answers);
+  submission.set('userId', user.id);
+  const acl = new Parse.ACL();
+  acl.setReadAccess(user, true);
+  acl.setWriteAccess(user, true);
+  acl.setRoleReadAccess(role, true);
+  acl.setRoleWriteAccess(role, true);
+  submission.setACL(acl);
+  return submission;
+};
 
 // Fetches the cached submissions related to a specific form
 export function loadCachedSubmissions(formId) {
@@ -24,8 +49,7 @@ function genSubmissionId(formId, user, done) {
 }
 
 /**
- * create a submission on parse-server
- * TODO set ACL in cloud code afterSave
+ * wrapper around Submission.create what will also save asychronously
  *
  * @param {string} id, the unique id for the realm record
  * @param {string} formId, the unique id for the parse form record
@@ -33,38 +57,21 @@ function genSubmissionId(formId, user, done) {
  * @param {object} currentUser, the current parse user saved to AsyncStorage
  */
 function createParseSubmission(id, formId, answers, user, done) {
-  const submission = new Submission();
-  submission.set('uniqueId', id);
-  submission.set('formId', formId);
-  submission.set('answers', answers);
-  submission.set('userId', user);
-  const query = new Parse.Query(Parse.Role);
-  query.equalTo('name', 'admin');
-  query.find(
-    (roles) => {
-      if (roles.length <= 0) {
-        return done('Invalid role.');
-      }
-      const role = roles[0];
-      const acl = new Parse.ACL();
-      acl.setReadAccess(user, true);
-      acl.setWriteAccess(user, true);
-      acl.setRoleReadAccess(role, true);
-      acl.setRoleWriteAccess(role, true);
-      submission.setACL(acl);
-      submission.save(null).then(
-        (s) => {
-          done(null, s);
-        },
-        () => {
-          done('Error synchronizing to remote server.');
-        }
-      );
-    },
-    () => {
+  adminRole((err, role) => {
+    if (err) {
       done('Invalid role.');
+      return;
     }
-  );
+    const submission = Submission.create(id, formId, answers, user, role);
+    submission.save(null).then(
+      (s) => {
+        done(null, s);
+      },
+      () => {
+        done('Network Error');
+      }
+    );
+  });
 }
 
 /**
@@ -80,7 +87,7 @@ function updateParseSubmission(submission, answers, done) {
         done(null, s);
       },
       () => {
-        done('Error synchronizing to remote server.');
+        done('Network Error');
       }
     );
   } else {
@@ -97,15 +104,38 @@ function findParseSubmission(id, done) {
   const query = new Parse.Query(Submission);
   query.equalTo('uniqueId', id);
   query.find(
-    (submission) => {
-      if (submission.length) {
-        done(null, submission[0]);
+    (submissions) => {
+      if (submissions && submissions.length) {
+        done(null, submissions[0]);
         return;
       }
       done(null, null);
     },
     () => {
-      done('No results');
+      done('Network Error');
+    }
+  );
+}
+
+/**
+ * finds submissions on parse by array of uniqueIds
+ *
+ * @param {array} uniqueIds, the unique ids for the records
+ * @callback {function} done, the callback in node.js format (err, res)
+ */
+function findParseSubmissions(uniqueIds, done) {
+  const query = new Parse.Query(Submission);
+  query.containedIn('uniqueId', uniqueIds);
+  query.find(
+    (submissions) => {
+      if (submissions && submissions.length) {
+        done(null, submissions);
+        return;
+      }
+      done(null, null);
+    },
+    () => {
+      done('Network Error');
     }
   );
 }
@@ -115,10 +145,11 @@ function findParseSubmission(id, done) {
  *
  * @param {string} id, the unique id for the realm record
  * @param {string} formId, the unique id for the parse form record
+ * @param {string} userId, the unique id for the currentUser
  * @param {object} answers, the answers to the current form
  * @param {boolean} dirty, mark the submission diry
  */
-function upsertRealmSubmission(id, formId, answers, dirty, done) {
+function upsertRealmSubmission(id, formId, userId, answers, dirty, done) {
   const submissions = realm.objects('Submission').filtered(
     `uniqueId = "${id}"`).sorted('created');
   const notification = realm.objects('Notification').filtered(`formId = "${formId}"`);
@@ -140,6 +171,7 @@ function upsertRealmSubmission(id, formId, answers, dirty, done) {
         const submission = realm.create('Submission', {
           uniqueId: id,
           formId: formId,
+          userId: userId,
           dirty: true,
           created: new Date(),
           answers: JSON.stringify(answers),
@@ -183,6 +215,7 @@ function markRealmSubmissionClean(id, done) {
 
 /**
  * save a submission to realm.io and attempt to propagte to parse-server
+ *
  * @param {string} formId, the unique id for the parse form record
  * @param {object} answers, the answers to the current form
  */
@@ -196,7 +229,7 @@ export function saveSubmission(formId, answers, done) {
     }],
     // save to realm and mark dirty
     dirty: ['id', (cb, results) => {
-      upsertRealmSubmission(results.id, formId, answers, true, cb);
+      upsertRealmSubmission(results.id, formId, results.currentUser.id, answers, true, cb);
     }],
     // TODO use cloud code for perform upsert vs. find then save
     // https://gist.github.com/kevinzhang96/1d4680b953e33342f6ab
@@ -217,9 +250,143 @@ export function saveSubmission(formId, answers, done) {
     }],
   }, (err) => {
     if (err) {
+      if (err === 'Network Error') {
+        return done(null, 'The submission was saved locally.');
+      }
+      return done(err);
+    }
+    done(null, 'The submission was saved.');
+  });
+}
+
+/**
+ * loads all cached submissions for the currentUser that are marked dirty
+ */
+export function loadDirtySubmissions(done) {
+  async.auto({
+    currentUser: (cb) => {
+      currentUser(cb);
+    },
+    submissions: ['currentUser', (cb, results) => {
+      const userId = results.currentUser.id;
+      const submissions = realm.objects('Submission').filtered(`userId == "${userId}"`).filtered('dirty == true');
+      cb(null, submissions);
+    }],
+  }, (err, results) => {
+    if (err) {
       done(err);
       return;
     }
-    done(null, 'The submission was saved.');
+    done(null, results.submissions);
+  });
+}
+
+/**
+ * attempt to save multiple chached submissions to the remote then mark as
+ * clean locally
+ *
+ * @param {array} submissions, array of realm.io model results
+ * @callback {function} done, the callback method in node.js format (err, res)
+ */
+export function propagateSubmissions(submissions, done) {
+  // let work with the realm.io objects in a local scoped array
+  const dirty = submissions.slice();
+  const uniqueIds = dirty.map((d) => d.uniqueId);
+  async.auto({
+    // get the current user
+    currentUser: (cb) => {
+      currentUser(cb);
+    },
+    // get the admin role
+    adminRole: ['currentUser', (cb) => {
+      adminRole(cb);
+    }],
+    // find existing parse objects
+    combined: ['adminRole', (cb, results) => {
+      findParseSubmissions(uniqueIds, (err, res) => {
+        if (err) {
+          return done(err);
+        }
+        if (res === null) {
+          done('Network Error');
+          return;
+        }
+        if (res && res.length > 0) {
+          // what are the existing uniqueIds on the server
+          const existingIds = res.map((e) => {
+            return e.get('uniqueId');
+          });
+          // what is the difference between the cache and server
+          const difference = _.difference(uniqueIds, existingIds);
+          // get any realm.io submissions that do not exist on the server?
+          const filtered = dirty.filter((d) => {
+            return difference.indexOf(d.uniqueId) >= 0;
+          });
+          // create the missing remote objects and add to an array
+          const missing = [];
+          filtered.forEach((d) => {
+            missing.push(Submission.create(d.uniqueId, d.formId, JSON.parse(d.answers), results.currentUser, results.adminRole));
+          });
+          // update the existing answers
+          res.forEach((e) => {
+            const s = dirty.filter((d) => {
+              return d.uniqueId === e.get('uniqueId');
+            })[0];
+            if (typeof s !== 'undefined') {
+              e.set('answers', JSON.parse(s.answers));
+            }
+          });
+          // combine all
+          const combined = _.union(res, missing);
+          cb(null, combined);
+          return;
+        }
+        cb(null, []);
+      });
+    }],
+    // Save all the objects in one http request
+    saveAll: ['combined', (cb, results) => {
+      const combined = results.combined;
+      const total = combined.length;
+      if (total > 0) {
+        Parse.Object.saveAll(combined,
+          () => {
+            done(null, total);
+          },
+          (e) => {
+            done(e);
+          }
+        );
+      }
+      cb(null, total);
+    }],
+    // mark the local submission as clean
+    clean: ['saveAll', (cb) => {
+      const numDirty = submissions.length;
+      let count = 0;
+      realm.write(() => {
+        submissions.forEach((submission) => {
+          count++;
+          if (typeof submission === 'undefined') {
+            return;
+          }
+          submission.dirty = false;
+          if (numDirty === count) {
+            cb(null, true);
+          }
+        });
+      });
+      cb(null, true);
+    }],
+  }, (err, results) => {
+    if (done && typeof done === 'function') {
+      if (err) {
+        if (err === 'Network Error') {
+          return done(null, 'The submission was saved locally.');
+        }
+        return done(err);
+      }
+      done(null, results.saveAll);
+    }
   });
 }

--- a/js/components/QuestionTypes/CompleteForm.js
+++ b/js/components/QuestionTypes/CompleteForm.js
@@ -8,12 +8,33 @@ import Button from 'apsl-react-native-button';
 import Icon from 'react-native-vector-icons/FontAwesome';
 
 const CompleteForm = React.createClass({
-  /* Render */
-  render() {
-    let buttonText = 'Submit';
+  getInitialState() {
+    return {
+      buttonText: 'Submit',
+    };
+  },
+  componentWillMount() {
     if (this.props.nextForm) {
-      buttonText = 'Submit and continue';
+      this.setState({
+        buttonText: 'Submit and continue',
+      });
     }
+  },
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.buttonText) {
+      this.setState({
+        buttonText: 'Submit and continue',
+      });
+    }
+  },
+  submitProxyHandler() {
+    this.setState({
+      buttonText: 'Saving...',
+    }, () => {
+      this.props.submit();
+    });
+  },
+  render() {
     return (
       <View style={Styles.question.block}>
         <View style={[Styles.question.header, Styles.question.headerComplete]} >
@@ -27,10 +48,10 @@ const CompleteForm = React.createClass({
             </Text>
           </View>
         </View>
-        <Button onPress={this.props.submit}
+        <Button onPress={this.submitProxyHandler}
                 style={[Styles.form.primaryButton, {marginTop: 30}]}
                 textStyle={Styles.form.primaryButtonText}>
-                {buttonText}
+                {this.state.buttonText}
         </Button>
       </View>
     );

--- a/js/data/Realm.js
+++ b/js/data/Realm.js
@@ -11,7 +11,7 @@ import TimeTrigger from '../models/TimeTrigger';
 import Test from '../models/Test';
 
 const realmInstance = new Realm({
-  schemaVersion: 42,
+  schemaVersion: 43,
   schema: [
     Survey,
     Form,

--- a/js/models/Submission.js
+++ b/js/models/Submission.js
@@ -7,6 +7,7 @@ Submission.schema = {
     dirty: 'bool',
     created: 'date',
     formId: 'string',
+    userId: 'string',
     // Serialized JSON
     answers: 'string',
   },

--- a/js/router/SharedNavigator.js
+++ b/js/router/SharedNavigator.js
@@ -22,9 +22,9 @@ import Styles from '../styles/Styles';
 // Model
 import Store from '../data/Store';
 
-// Parse
 import {connectToParseServer} from '../api/ParseServer';
 import {isAuthenticated, logout} from '../api/Account';
+import {checkDirtyObjects} from '../services/CheckDirty';
 
 // Views
 import LoginPage from '../views/LoginPage';
@@ -90,19 +90,36 @@ const SharedNavigator = React.createClass({
         onNotification: this._onNotification,
       });
     }
-    checkTimeTriggers();
+    // see if we have an authenticated user
+    isAuthenticated((authenticated) => {
+      if (authenticated) {
+        checkTimeTriggers();
+        checkDirtyObjects((err, res) => {
+          if (err) {
+            console.warn(err);
+          }
+          if (res) {
+            console.log(res);
+          }
+          // set state after the check is complete
+          this.setState({
+            isAuthenticated: authenticated,
+            isLoading: false,
+          });
+        });
+      } else {
+        this.setState({
+          isAuthenticated: authenticated,
+          isLoading: false,
+        });
+      }
+    });
   },
 
   componentDidMount() {
     if (Platform.OS === 'ios') {
       PushNotification.requestPermissions();
     }
-    isAuthenticated((authenticated) => {
-      this.setState({
-        isAuthenticated: authenticated,
-        isLoading: false,
-      });
-    });
   },
 
   _onNotification(notification) {

--- a/js/services/CheckDirty.js
+++ b/js/services/CheckDirty.js
@@ -1,0 +1,62 @@
+import async from 'async';
+import { currentUser } from '../api/Account';
+import { loadDirtySubmissions, propagateSubmissions } from '../api/Submissions';
+import { loadDirtyInvitations, propagateInvitations } from '../api/Invitations';
+
+/**
+ * service that checks for dirty invitations and submissions and attempts to
+ * propagate them to the remote server (in bulk)
+ *
+ * @param {function} done, in node.js format (err, res)
+ */
+export function checkDirtyObjects(done) {
+  async.auto({
+    // get the current user of our multi-user application
+    currentUser: (cb) => {
+      currentUser(cb);
+    },
+    // checks for dirty Invitations
+    dirtyInvitations: ['currentUser', (cb) => {
+      loadDirtyInvitations(cb);
+    }],
+    // checks for dirty submissions
+    dirtySubmissions: ['currentUser', (cb) => {
+      loadDirtySubmissions(cb);
+    }],
+    // marks any dirty invitations as clean
+    cleanedInvitations: ['dirtyInvitations', (cb, results) => {
+      const numDirty = results.dirtyInvitations.length;
+      if (numDirty > 0) {
+        propagateInvitations(results.dirtyInvitations, (err, res) => {
+          if (err) {
+            return cb(null, 0);
+          }
+          cb(null, res);
+        });
+      } else {
+        cb(null, 0);
+      }
+    }],
+    // marks any dirty submissions as clean
+    cleanedSubmissions: ['dirtySubmissions', (cb, results) => {
+      const numDirty = results.dirtySubmissions.length;
+      if (numDirty > 0) {
+        propagateSubmissions(results.dirtySubmissions, (err, res) => {
+          if (err) {
+            return cb(null, 0);
+          }
+          cb(null, res);
+        });
+      } else {
+        cb(null, 0);
+      }
+    }],
+  }, (err, results) => {
+    if (done && typeof done === 'function') {
+      if (err) {
+        return done(err);
+      }
+      return done(null, results);
+    }
+  });
+}

--- a/js/views/FormPage.js
+++ b/js/views/FormPage.js
@@ -231,10 +231,6 @@ const FormPage = React.createClass({
     const formId = this.form.id;
     const index = this.state.index;
     const survey = this.props.survey;
-    this.setState({
-      buttonText: 'Saving...',
-    });
-
     saveSubmission(formId, answers, (err) => {
       if (err) {
         if (err === 'Invalid User') {
@@ -244,10 +240,6 @@ const FormPage = React.createClass({
         Alert.alert('Error', err);
         return;
       }
-
-      this.setState({
-        buttonText: 'Submit',
-      });
 
       // Publish a ToastMessage to our Toaster via pubsub
       const toastMessage = ToastMessage.createFromObject({title: 'Success', message: 'The form has been submitted.', icon: 'check', iconColor: Color.fadedGreen});

--- a/js/views/SurveyDetailsPage.js
+++ b/js/views/SurveyDetailsPage.js
@@ -23,36 +23,53 @@ const SurveyDetailsPage = React.createClass({
   getInitialState() {
     return {
       status: InvitationStatus.PENDING,
+      acceptText: 'Accept',
+      declineText: 'Decline',
     };
   },
   /* Methods */
 
   acceptSurvey() {
     const status = InvitationStatus.ACCEPTED;
-    this.setState({status: status});
-    markInvitationStatus(this.props.survey.id, status, (err) => {
-      if (err) {
-        console.warn(err);
-        return;
-      }
-      checkSurveyTimeTriggers(this.props.survey, true);
-      this.props.navigator.push({
-        path: 'form',
-        title: this.props.survey.title,
-        survey: this.props.survey,
+    this.setState({
+      status: status,
+      acceptText: 'Saving ...',
+    }, () => {
+      markInvitationStatus(this.props.survey.id, status, (err) => {
+        this.setState({
+          acceptText: 'Accept',
+        });
+        if (err) {
+          console.warn(err);
+          return;
+        }
+        checkSurveyTimeTriggers(this.props.survey, true);
+        this.props.navigator.push({
+          path: 'form',
+          title: this.props.survey.title,
+          survey: this.props.survey,
+        });
       });
     });
   },
 
   declineSurvey() {
     const status = InvitationStatus.DECLINED;
-    this.setState({status: status});
-    markInvitationStatus(this.props.survey.id, status, (err) => {
-      if (err) {
-        console.warn(err);
-        return;
-      }
-      this.props.navigator.pop();
+    this.setState({
+      status: status,
+      declineText: 'Saving ...',
+    }, () => {
+      this.setState({status: status});
+      markInvitationStatus(this.props.survey.id, status, (err) => {
+        this.setState({
+          acceptText: 'Decline',
+        });
+        if (err) {
+          console.warn(err);
+          return;
+        }
+        this.props.navigator.pop();
+      });
     });
   },
 
@@ -97,10 +114,12 @@ const SurveyDetailsPage = React.createClass({
 
         <View style={[Styles.survey.acceptanceButtons, {padding: 0}]}>
           <Button style={acceptButtonStyle} textStyle={acceptButtonTextStyle} action={this.acceptSurvey}>
-            <Icon name='check-circle' size={18} color={this.state.status === 'accepted' ? Color.background2 : Color.positive} /> Accept
+            <Icon name='check-circle' size={18} color={this.state.status === 'accepted' ? Color.background2 : Color.positive} />
+            <Text> {this.state.acceptText} </Text>
           </Button>
           <Button style={declineButtonStyle} textStyle={declineButtonTextStyle} action={this.declineSurvey}>
-            <Icon name='times-circle' size={18} color={this.state.status === 'declined' ? Color.background2 : Color.warning} /> Decline
+            <Icon name='times-circle' size={18} color={this.state.status === 'declined' ? Color.background2 : Color.warning} />
+            <Text> {this.state.declineText} </Text>
           </Button>
         </View>
       </View>

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "apsl-react-native-button": "2.4.2",
     "async": "1.5.2",
-    "colors": "^1.1.2",
-    "crypto-js": "^3.1.6",
+    "colors": "1.1.2",
+    "crypto-js": "3.1.6",
     "he": "1.1.0",
     "lodash": "4.11.1",
     "moment": "2.11.2",


### PR DESCRIPTION
# Changes
- simplify how to load/check the cache
- no longer 'auto' refresh the cache, this is a significant HTTP
  request/response overhead (loading forms, questions, triggers) that
  should only be done when the user manually refreshes
# New Features
- since we are using a REST api through parse, the concept of having a 'connection' does not exist, like in websocket based frameworks.  (relies on a stateless, client-server, cacheable communications protocol)
- enables working offline 'silently' though detection of 'Network Error' within async callbacks
- when a 'Network Error' occurs, objects are left marked as 'dirty'
- the check for dirty objects is blocking and occurs at application startup, if a Network Error does not occur, the dirty objects will be marked as 'clean'

An additional feature may be to check for dirty objects upon changes in the device network state.
