### PR TITLE
Adds support for push notifications received on the foreground

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -77,10 +77,7 @@ module.exports = {
         "before": true
       }
     ],
-    "linebreak-style": [
-      "error",
-      "unix"
-    ],
+    "linebreak-style": "off",
     "lines-around-comment": "off",
     "max-depth": "error",
     "max-len": "off",
@@ -166,7 +163,7 @@ module.exports = {
     "no-unmodified-loop-condition": "error",
     "no-unneeded-ternary": "error",
     "no-unused-expressions": "error",
-    "no-use-before-define": "error",
+    "no-use-before-define": "off",
     "no-useless-call": "error",
     "no-useless-computed-key": "error",
     "no-useless-concat": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,7 +54,7 @@ module.exports = {
     "consistent-this": "error",
     "curly": "error",
     "default-case": "error",
-    "dot-location": "error",
+    "dot-location": ["error", "property"],
     "dot-notation": "error",
     "eol-last": "error",
     "eqeqeq": "error",

--- a/js/api/Forms.js
+++ b/js/api/Forms.js
@@ -22,6 +22,10 @@ export function cacheParseForm(form, surveyId) {
 // Returns an object containing a form and its parent survey
 export function loadCachedFormDataById(formId) {
   const form = realm.objects('Form').filtered(`id = "${formId}"`)[0];
+  if (!form) {
+    console.warn(`Error: No form data found with the id: ${formId}`);
+    return;
+  }
   const forms = realm.objects('Form').filtered(`surveyId = "${form.surveyId}"`).sorted('order');
   const index = forms.findIndex((f) => {
     return f.id === form.id;

--- a/js/api/Notifications.js
+++ b/js/api/Notifications.js
@@ -5,7 +5,8 @@ import Settings from '../settings';
 import realm from '../data/Realm';
 import Store from '../data/Store';
 
-import { upsertInstallation } from '../api/Installations';
+import { loadCachedFormDataById } from './Forms';
+import { upsertInstallation } from './Installations';
 
 
 export function initializeNotifications() {
@@ -43,6 +44,8 @@ function _onRegister(registration) {
 }
 
 function _onNotification(notification) {
+  console.log("GOT NOTIFICATION");
+  console.log(notification);
   if (typeof notification === 'undefined') {
     return;
   }
@@ -93,13 +96,14 @@ export function markNotificationsAsViewed(notifications) {
   });
 }
 
-export function clearNotifications(notifications) {
-  const notificationLength = notifications.length;
-  console.warn(notifications)
+/**
+ * Deletes all current notifications
+ * @return {[type]} [description]
+ */
+export function clearNotifications() {
+  const notifications = loadNotifications();
   realm.write(() => {
-    for (let i = 0; i < notificationLength; i++) {
-      notifications[i].complete = true;
-    }
+    realm.delete(notifications);
   });
 }
 

--- a/js/api/Notifications.js
+++ b/js/api/Notifications.js
@@ -1,11 +1,13 @@
 import { Platform, AppState } from 'react-native';
 import PushNotification from 'react-native-push-notification';
 import pubsub from 'pubsub-js';
+import async from 'async';
 
 import Settings from '../settings';
 import realm from '../data/Realm';
 import Store from '../data/Store';
 
+import { currentUser } from './Account';
 import { loadCachedFormDataById } from './Forms';
 import { upsertInstallation } from './Installations';
 
@@ -34,6 +36,67 @@ export function initializeNotifications() {
   Store.newNotifications = newNotifications.length;
 }
 
+function handleNewNotification(notification) {
+  async.auto({
+    user: (cb) => {
+      currentUser(cb);
+    },
+    data: (cb) => {
+      const data = loadCachedFormDataById(notification.data.formId);
+      if (data) {
+        cb(null, data);
+      } else {
+        cb(`Unable to find form data with id ${notification.data.formId}`);
+      }
+    },
+    appNotification: ['user', 'data', (cb, results) => {
+      const data = results.data;
+      if (typeof data === 'undefined' || typeof data.survey === 'undefined' || typeof data.form === 'undefined' || typeof results.user === 'undefined') {
+        return;
+      }
+
+      const userId = notification.userId || results.user.id;
+      if (!userId) {
+        console.warn(`Unable to find userId for notification ${notification.push_id}`);
+        return;
+      }
+
+      const newNotification = addAppNotification({
+        id: notification.push_id,
+        userId: userId,
+        surveyId: data.survey.id,
+        formId: data.form.id,
+        title: data.form.title,
+        description: notification.message,
+        time: new Date(),
+      });
+
+      if (notification.foreground) {
+        if (AppState.currentState !== 'active') {
+          const path = {path: 'form', title: data.survey.title, survey: data.survey, form: data.form, index: data.index};
+          const routeStack = [
+            {path: 'surveylist', title: 'Surveys'},
+            path,
+          ];
+          if (Store.navigator) {
+            Store.navigator.immediatelyResetRouteStack(routeStack);
+          } else {
+            Store.initialRouteStack = routeStack;
+          }
+        }
+      }
+
+      cb(null, newNotification);
+    }],
+  }, (err, results) => {
+    if (err) {
+      console.warn(err);
+      return;
+    }
+    console.log(`Added notification: ${results.appNotification.id}`);
+  });
+}
+
 function _onRegister(registration) {
   const token = registration.token;
   const platform = registration.os;
@@ -59,46 +122,38 @@ function _onNotification(notification) {
   console.log(`New notification received: ${notification.push_id}`);
 
   if (notification.hasOwnProperty('push_id') && notification.hasOwnProperty('data') && notification.data.hasOwnProperty('formId')) {
-
-    const data = loadCachedFormDataById(notification.data.formId);
-    if (typeof data === 'undefined' || typeof data.survey === 'undefined' || typeof data.form === 'undefined') {
-      return;
-    }
-
-    addAppNotification({
-      id: notification.push_id,
-      surveyId: data.survey.id,
-      formId: data.form.id,
-      title: data.form.title,
-      description: notification.message,
-      time: new Date(),
-    });
-
-    if (notification.foreground) {
-      if (AppState.currentState !== 'active') {
-        const path = {path: 'form', title: data.survey.title, survey: data.survey, form: data.form, index: data.index};
-        const routeStack = [
-          {path: 'surveylist', title: 'Surveys'},
-          path,
-        ];
-        if (Store.navigator) {
-          Store.navigator.immediatelyResetRouteStack(routeStack);
-        } else {
-          Store.initialRouteStack = routeStack;
-        }
-      }
-    }
+    handleNewNotification(notification);
   }
 }
 
-// Finds and returns a list of pending Notifications from Realm
+/**
+ * // Finds and returns a list of pending Notifications from the Realm database.
+ * @param  {object} options           Object containing filter options for the Realm query.
+ * @param  {object} options.newOnly   If true, will filter out all Notification objects that have been viewed already.
+ * @return {object}                   Realm object conatining a list of 'Notification' objects.
+ */
 export function loadNotifications(options = {}) {
   let filter = 'complete == false';
   filter += options.newOnly ? ' AND viewed == false' : '';
 
-  return realm.objects('Notification').filtered(
-    filter).sorted(
-      'datetime', true);
+  return realm.objects('Notification')
+                .filtered(filter)
+                .sorted('datetime', true);
+}
+
+/**
+ * Finds a list of pending Notifications for the current user and returns it via callback.
+ * @param  {Object} options    Object containing filter options for loadNotifications().
+ */
+export function loadUserNotifications(options = {}, callback) {
+  currentUser((err, user) => {
+    if (err) {
+      callback(err);
+      return;
+    }
+    const userNotifications = loadNotifications({...options, userId: user.id});
+    callback(null, userNotifications);
+  });
 }
 
 /**
@@ -161,6 +216,7 @@ export function addAppNotification(notification) {
         id: notification.id,
         surveyId: notification.surveyId,
         formId: notification.formId,
+        userId: notification.userId,
         title: notification.title,
         description: notification.description,
         datetime: notification.time,

--- a/js/api/Notifications.js
+++ b/js/api/Notifications.js
@@ -75,10 +75,7 @@ function _onNotification(notification) {
     });
 
     if (notification.foreground) {
-      if (AppState.currentState === 'active') {
-        Store.newNotifications++;
-        pubsub.publish('onNotification', appNotification);
-      } else {
+      if (AppState.currentState !== 'active') {
         const path = {path: 'form', title: data.survey.title, survey: data.survey, form: data.form, index: data.index};
         const routeStack = [
           {path: 'surveylist', title: 'Surveys'},
@@ -169,6 +166,8 @@ export function addAppNotification(notification) {
         datetime: notification.time,
       }, true);
     });
+    Store.newNotifications++;
+    pubsub.publish('onNotification', newNotification);
     return newNotification;
   } catch (e) {
     console.error(e);

--- a/js/api/Notifications.js
+++ b/js/api/Notifications.js
@@ -32,8 +32,11 @@ export function initializeNotifications() {
   }
 
   // Cache count of new notifications in the Store
-  const newNotifications = loadNotifications({newOnly: true});
-  Store.newNotifications = newNotifications.length;
+  loadUserNotifications({newOnly: true}, (err, notifications) => {
+    if (err || !notifications) {
+      return;
+    }
+  });
 }
 
 function handleNewNotification(notification) {
@@ -97,6 +100,10 @@ function handleNewNotification(notification) {
   });
 }
 
+/**
+ * Event fired on initialization of the notification service.
+ * @param  {object} registration Object containing data returned by the user's phone.
+ */
 function _onRegister(registration) {
   const token = registration.token;
   const platform = registration.os;
@@ -173,9 +180,14 @@ export function markNotificationsAsViewed(notifications) {
  * Deletes all current notifications from the Realm database
  */
 export function clearNotifications() {
-  const notifications = loadNotifications();
-  realm.write(() => {
-    realm.delete(notifications);
+  loadUserNotifications({}, (err, notifications) => {
+    if (err) {
+      console.warn(err);
+      return;
+    }
+    realm.write(() => {
+      realm.delete(notifications);
+    });
   });
 }
 

--- a/js/api/Notifications.js
+++ b/js/api/Notifications.js
@@ -1,5 +1,8 @@
 import realm from '../data/Realm';
 
+export let newNotifications = 0;
+
+
 // Finds and returns a list of pending Notifications from Realm
 export function loadNotifications() {
   return realm.objects('Notification').filtered(

--- a/js/api/Notifications.js
+++ b/js/api/Notifications.js
@@ -65,7 +65,7 @@ function _onNotification(notification) {
       return;
     }
 
-    const appNotification = addAppNotification({
+    addAppNotification({
       id: notification.push_id,
       surveyId: data.survey.id,
       formId: data.form.id,

--- a/js/api/Notifications.js
+++ b/js/api/Notifications.js
@@ -154,6 +154,9 @@ export function clearNotification(notification) {
  * @return {object}                         New Realm object of the type 'Notification'
  */
 export function addAppNotification(notification) {
+  if (!notification) {
+    return;
+  }
   try {
     let newNotification = null;
     realm.write(() => {

--- a/js/api/Notifications.js
+++ b/js/api/Notifications.js
@@ -52,15 +52,14 @@ function _onNotification(notification) {
   console.log(`New notification received: ${notification.push_id}`);
 
   if (notification.hasOwnProperty('data') && notification.data.hasOwnProperty('formId')) {
-
-    const data = loadCachedFormDataById(notification.data.formId);
-    if (typeof data === 'undefined' || typeof data.survey === 'undefined' || typeof data.form === 'undefined') {
-      return;
-    }
-    const path = {path: 'form', title: data.survey.title, survey: data.survey, form: data.form, index: data.index};
-    const appNotification = addAppNotification(data.survey.id, data.form.id, data.form.title, notification.message, new Date());
-
     if (notification.foreground) {
+      const data = loadCachedFormDataById(notification.data.formId);
+      if (typeof data === 'undefined' || typeof data.survey === 'undefined' || typeof data.form === 'undefined') {
+        return;
+      }
+      const path = {path: 'form', title: data.survey.title, survey: data.survey, form: data.form, index: data.index};
+      const appNotification = addAppNotification(data.survey.id, data.form.id, data.form.title, notification.message, new Date());
+
       if (AppState.currentState === 'active') {
         Store.newNotifications++;
         pubsub.publish('onNotification', appNotification);

--- a/js/api/Notifications.js
+++ b/js/api/Notifications.js
@@ -1,13 +1,106 @@
+import { Platform } from 'react-native';
+import PushNotification from 'react-native-push-notification';
+
+import Settings from '../settings';
 import realm from '../data/Realm';
+import Store from '../data/Store';
 
-export let newNotifications = 0;
+import { upsertInstallation } from '../api/Installations';
 
+
+export function initializeNotifications() {
+  // Configure Push Notifications
+  if (Platform.OS === 'android') {
+    PushNotification.configure({
+      senderID: Settings.senderID,
+      onRegister: _onRegister,
+      onNotification: _onNotification,
+    });
+  } else {
+    PushNotification.configure({
+      onRegister: _onRegister,
+      onNotification: _onNotification,
+    });
+  }
+
+  // Store count of new notifications
+  const newNotifications = loadNotifications({newOnly: true});
+  Store.newNotifications = newNotifications.length;
+}
+
+function _onRegister(registration) {
+  const token = registration.token;
+  const platform = registration.os;
+  if (platform === 'ios') {
+    PushNotification.setApplicationIconBadgeNumber(0);
+  }
+  upsertInstallation(token, platform, (err) => {
+    if (err) {
+      console.error(err);
+      return;
+    }
+  });
+}
+
+function _onNotification(notification) {
+  if (typeof notification === 'undefined') {
+    return;
+  }
+  // TODO determine the type of notification
+  if (notification.hasOwnProperty('data') && notification.data.hasOwnProperty('formId')) {
+    const data = loadCachedFormDataById(notification.data.formId);
+    if (typeof data === 'undefined' || typeof data.survey === 'undefined' || typeof data.form === 'undefined') {
+      return;
+    }
+    const path = {path: 'form', title: data.survey.title, survey: data.survey, form: data.form, index: data.index};
+    // TODO sync remote and cached notifications
+    // addTimeTriggerNotification(data.survey.id, data.form.id, data.form.title, notification.message, new Date());
+    // We will only route the user if notification was remote
+    if (notification.foreground) {
+      Store.newNotifications++;
+      if (this._header) {
+        this._header.updateNotifications();
+      }
+      if (this._controlPanel) {
+        this._controlPanel.updateNotifications();
+      }
+    } else {
+      if (Store.navigator) {
+        Store.navigator.resetTo(path);
+      } else {
+        Store.initialRoute = path;
+      }
+    }
+  }
+}
 
 // Finds and returns a list of pending Notifications from Realm
-export function loadNotifications() {
+export function loadNotifications(options = {}) {
+  let filter = 'complete == false';
+  filter += options.newOnly ? ' AND viewed == false' : '';
+
   return realm.objects('Notification').filtered(
-    'complete == false').sorted(
+    filter).sorted(
       'datetime', true);
+}
+
+export function markNotificationsAsViewed(notifications) {
+  const notificationLength = notifications.length;
+  realm.write(() => {
+    for (let i = 0; i < notificationLength; i++) {
+      notifications[i].viewed = true;
+    }
+  });
+}
+
+export function clearNotifications(notifications) {
+  const notificationLength = notifications.length;
+  console.warn(notifications)
+  realm.write(() => {
+    for (let i = 0; i < notificationLength; i++) {
+      notifications[i].complete = true;
+    }
+  });
 }
 
 // Creates a new notification for an active Time Trigger

--- a/js/api/Submissions.js
+++ b/js/api/Submissions.js
@@ -177,7 +177,7 @@ function upsertRealmSubmission(id, formId, userId, answers, dirty, done) {
           answers: JSON.stringify(answers),
         });
         if (notification) {
-          notification.complete = true;
+          realm.delete(notification);
         }
         if (timeTrigger) {
           timeTrigger.complete = true;

--- a/js/api/Triggers.js
+++ b/js/api/Triggers.js
@@ -1,6 +1,7 @@
 import Parse from 'parse/react-native';
 import realm from '../data/Realm';
 import { loadAcceptedInvitations } from '../api/Invitations';
+import { addTimeTriggerNotification } from '../api/Notifications';
 
 // Saves a Form object from Parse into our Realm.io local database
 function cacheTimeTrigger(trigger, form, survey) {
@@ -79,14 +80,7 @@ export function checkSurveyTimeTriggers(survey, omitNotifications) {
         }, true);
 
         if (!omitNotifications) {
-          // TODO Replace with more descriptive messages in the future.
-          realm.create('Notification', {
-            surveyId: activeTrigger.surveyId,
-            formId: activeTrigger.formId,
-            title: activeTrigger.title,
-            description: 'A scheduled survey form is available.',
-            datetime: activeTrigger.datetime,
-          }, true);
+          addTimeTriggerNotification(activeTrigger.surveyId, activeTrigger.formId, activeTrigger.title, 'A new scheduled survey form is available.', activeTrigger.datetime);
         }
       }
     }

--- a/js/components/ControlPanelItem.js
+++ b/js/components/ControlPanelItem.js
@@ -2,17 +2,51 @@ import React, {
   View,
   Text,
   TouchableWithoutFeedback,
+  StyleSheet,
 } from 'react-native';
 
+import Color from '../styles/Color';
 import Styles from '../styles/Styles';
 
+const _styles = StyleSheet.create({
+  counter: {
+    position: 'absolute',
+    top: 17,
+    right: 10,
+    width: 30,
+    height: 30,
+    backgroundColor: Color.warning,
+    borderRadius: 30,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  counterText: {
+    color: Color.background2,
+    fontWeight: 'bold',
+  },
+});
+
 export default React.createClass({
+  getInitialState() {
+    return {
+      counter: 25,
+    };
+  },
+
+  /* Render */
   render() {
     return (
       <View style={Styles.controlPanel.itemContainer}>
         <TouchableWithoutFeedback onPress={this.props.onPress}>
           <View style={[Styles.controlPanel.item]}>
             <Text style={Styles.controlPanel.itemText}>{this.props.text}</Text>
+            {
+              this.state.counter > 0
+              ? <View style={_styles.counter}>
+                  <Text style={_styles.counterText}>{this.state.counter}</Text>
+                </View>
+              : null
+            }
           </View>
         </TouchableWithoutFeedback>
       </View>

--- a/js/components/ControlPanelItem.js
+++ b/js/components/ControlPanelItem.js
@@ -27,10 +27,26 @@ const _styles = StyleSheet.create({
 });
 
 export default React.createClass({
+  propTypes: {
+    counter: React.PropTypes.number,
+  },
+
+  getDefaultProps() {
+    return {
+      counter: 0,
+    };
+  },
+
   getInitialState() {
     return {
-      counter: 25,
+      counter: this.props.counter,
     };
+  },
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      counter: nextProps.counter,
+    });
   },
 
   /* Render */

--- a/js/components/Header.js
+++ b/js/components/Header.js
@@ -8,10 +8,12 @@ import React, {
   Easing,
   StyleSheet,
 } from 'react-native';
+import Icon from 'react-native-vector-icons/FontAwesome';
 
 import Styles from '../styles/Styles';
 import Color from '../styles/Color';
-import Icon from 'react-native-vector-icons/FontAwesome';
+
+import Store from '../data/Store';
 
 const _styles = StyleSheet.create({
   notificationIcon: {
@@ -44,6 +46,7 @@ const Header = React.createClass({
       bounceValue: new Animated.Value(0),
       fadeAnim: new Animated.Value(0),
       translateAnim: new Animated.Value(0),
+      hasNewNotifications: Store.newNotifications > 0,
     };
   },
 
@@ -91,10 +94,15 @@ const Header = React.createClass({
         title: title,
         index: position,
         path: path,
+        hasNewNotifications: Store.newNotifications,
       });
     } catch (e) {
       console.warn(e);
     }
+  },
+
+  updateNotifications() {
+    this.setState({hasNewNotifications: Store.newNotifications > 0});
   },
 
   backToLogin() {
@@ -129,7 +137,11 @@ const Header = React.createClass({
       <TouchableWithoutFeedback onPress={this.props.openDrawer}>
         <View style={Styles.header.navBarRightButton}>
           <Icon name='bars' size={25} color='#FFFFFF' />
-          <View style={_styles.notificationIcon} />
+          {
+            this.state.hasNewNotifications
+            ? <View style={_styles.notificationIcon} />
+            : null
+          }
         </View>
       </TouchableWithoutFeedback>
     );

--- a/js/components/Header.js
+++ b/js/components/Header.js
@@ -26,7 +26,7 @@ const _styles = StyleSheet.create({
     height: 12,
     borderRadius: 10,
     borderWidth: 2,
-    borderColor: Color.background1
+    borderColor: Color.background1,
   },
 });
 
@@ -55,7 +55,7 @@ const Header = React.createClass({
     // NoOp https://github.com/facebook/react-native/issues/6205
   },
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps() {
     this.updateTitle();
   },
 

--- a/js/components/Header.js
+++ b/js/components/Header.js
@@ -6,11 +6,26 @@ import React, {
   Platform,
   Animated,
   Easing,
+  StyleSheet,
 } from 'react-native';
 
 import Styles from '../styles/Styles';
 import Color from '../styles/Color';
 import Icon from 'react-native-vector-icons/FontAwesome';
+
+const _styles = StyleSheet.create({
+  notificationIcon: {
+    position: 'absolute',
+    top: 20,
+    right: 16,
+    backgroundColor: Color.warning,
+    width: 12,
+    height: 12,
+    borderRadius: 10,
+    borderWidth: 2,
+    borderColor: Color.background1
+  },
+});
 
 const Header = React.createClass({
   propTypes: {
@@ -114,6 +129,7 @@ const Header = React.createClass({
       <TouchableWithoutFeedback onPress={this.props.openDrawer}>
         <View style={Styles.header.navBarRightButton}>
           <Icon name='bars' size={25} color='#FFFFFF' />
+          <View style={_styles.notificationIcon} />
         </View>
       </TouchableWithoutFeedback>
     );
@@ -144,13 +160,13 @@ const Header = React.createClass({
     return (
       <View style={navbarStyles}>
         {this.renderIOSPadding()}
-          <TouchableWithoutFeedback onPress={this.navigateBack}>
-            {
-            this.state.index > 0
-              ? <View style={Styles.header.navBarLeftButton}><Icon name='chevron-left' size={25} color='#FFFFFF' /></View>
-              : <View style={Styles.header.navBarLeftButton}><Icon name='chevron-left' size={25} color={Color.background1} /></View>
-            }
-          </TouchableWithoutFeedback>
+        <TouchableWithoutFeedback onPress={this.navigateBack}>
+          {
+          this.state.index > 0
+            ? <View style={Styles.header.navBarLeftButton}><Icon name='chevron-left' size={25} color='#FFFFFF' /></View>
+            : <View style={Styles.header.navBarLeftButton}><Icon name='chevron-left' size={25} color={Color.background1} /></View>
+          }
+        </TouchableWithoutFeedback>
         <View style={Styles.header.navBarTitle}>
           <Animated.Text
             source={{uri: 'http://i.imgur.com/XMKOH81.jpg'}}

--- a/js/components/Header.js
+++ b/js/components/Header.js
@@ -8,6 +8,7 @@ import React, {
   Easing,
   StyleSheet,
 } from 'react-native';
+import pubsub from 'pubsub-js';
 import Icon from 'react-native-vector-icons/FontAwesome';
 
 import Styles from '../styles/Styles';
@@ -55,7 +56,7 @@ const Header = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    this.updateTitle(nextProps.navigator);
+    this.updateTitle();
   },
 
   componentDidMount() {
@@ -63,12 +64,16 @@ const Header = React.createClass({
       this.state.fadeAnim,
       {toValue: 1}
     ).start();
+
+    pubsub.subscribe('onNotification', () => {
+      this.updateTitle();
+    });
   },
 
   /* Methods */
-  updateTitle(navigator, indexOffset = 0) {
-    try {
-      const routeStack = navigator.getCurrentRoutes();
+  updateTitle(indexOffset = 0) {
+    if (Store.navigator) {
+      const routeStack = Store.navigator.getCurrentRoutes();
       const position = routeStack.length - 1 - indexOffset;
       let title = this.state.title;
       let path = this.state.path;
@@ -96,8 +101,6 @@ const Header = React.createClass({
         path: path,
         hasNewNotifications: Store.newNotifications,
       });
-    } catch (e) {
-      console.warn(e);
     }
   },
 
@@ -121,7 +124,7 @@ const Header = React.createClass({
         ]
       );
     } else {
-      this.updateTitle(this.props.navigator, 1);
+      this.updateTitle(1);
       this.props.navigator.pop();
     }
   },

--- a/js/data/Realm.js
+++ b/js/data/Realm.js
@@ -11,7 +11,7 @@ import TimeTrigger from '../models/TimeTrigger';
 import Test from '../models/Test';
 
 const realmInstance = new Realm({
-  schemaVersion: 43,
+  schemaVersion: 45,
   schema: [
     Survey,
     Form,

--- a/js/data/Realm.js
+++ b/js/data/Realm.js
@@ -11,7 +11,7 @@ import TimeTrigger from '../models/TimeTrigger';
 import Test from '../models/Test';
 
 const realmInstance = new Realm({
-  schemaVersion: 45,
+  schemaVersion: 46,
   schema: [
     Survey,
     Form,

--- a/js/data/Realm.js
+++ b/js/data/Realm.js
@@ -11,7 +11,7 @@ import TimeTrigger from '../models/TimeTrigger';
 import Test from '../models/Test';
 
 const realmInstance = new Realm({
-  schemaVersion: 46,
+  schemaVersion: 47,
   schema: [
     Survey,
     Form,

--- a/js/data/Store.js
+++ b/js/data/Store.js
@@ -7,10 +7,9 @@ const Store = {
   navigator: false,
 
   // Shared variables
-  initialRoute: { 
-    path: 'surveylist',
-    title: 'Surveys',
-  },
+  initialRouteStack: [
+    { path: 'surveylist', title: 'Surveys' },
+  ],
   newNotifications: 0,
 };
 

--- a/js/data/Store.js
+++ b/js/data/Store.js
@@ -1,8 +1,17 @@
 // Used for caching global variables that may not fit in a Realm database
 const Store = {
-  // Timestamp
+  // Cache control
   lastParseUpdate: 0,
+
+  // Global component refs
   navigator: false,
+
+  // Shared variables
+  initialRoute: { 
+    path: 'surveylist',
+    title: 'Surveys',
+  },
+  newNotifications: 0,
 };
 
 module.exports = Store;

--- a/js/models/Notification.js
+++ b/js/models/Notification.js
@@ -1,8 +1,9 @@
-export default class Notification {}
+export default class Notification{}
 Notification.schema = {
   name: 'Notification',
-  primaryKey: 'formId',
+  primaryKey: 'id',
   properties: {
+    id: 'string',
     formId: 'string',
     surveyId: 'string',
     title: 'string',

--- a/js/models/Notification.js
+++ b/js/models/Notification.js
@@ -8,6 +8,10 @@ Notification.schema = {
     title: 'string',
     description: 'string',
     datetime: 'date',
+    viewed: {
+      type: 'bool',
+      default: false,
+    },
     complete: {
       type: 'bool',
       default: false,

--- a/js/models/Notification.js
+++ b/js/models/Notification.js
@@ -1,4 +1,4 @@
-export default class Notification{}
+export default class Notification {}
 Notification.schema = {
   name: 'Notification',
   primaryKey: 'id',

--- a/js/models/Notification.js
+++ b/js/models/Notification.js
@@ -5,6 +5,7 @@ Notification.schema = {
   properties: {
     id: 'string',
     formId: 'string',
+    userId: 'string',
     surveyId: 'string',
     title: 'string',
     description: 'string',

--- a/js/router/SharedNavigator.js
+++ b/js/router/SharedNavigator.js
@@ -44,7 +44,7 @@ import { initializeNotifications } from '../api/Notifications';
 connectToParseServer(Settings.parse.serverUrl, Settings.parse.appId);
 
 let navigator = null;
-let initialRoute = Store.initialRoute;
+let initialRouteStack = Store.initialRouteStack;
 const toaster = <Toaster key='toaster' />;
 
 // Binds the hardware "back button" from Android devices
@@ -265,7 +265,7 @@ const SharedNavigator = React.createClass({
                // Store globally so we can use the navigator outside components
               Store.navigator = nav;
             }}
-            initialRoute={initialRoute}
+            initialRouteStack={initialRouteStack}
             renderScene={this.routeMapper}
             configureScene={(route) => this.setSceneConfig(route)}
             style={{flex: 1}}
@@ -287,7 +287,7 @@ const SharedNavigator = React.createClass({
         ref={(nav) => {
           navigator = nav;
         }}
-        initialRoute={initialRoute}
+        initialRouteStack={initialRouteStack}
         renderScene={this.routeMapper}
         configureScene={(route) => this.setSceneConfig(route)}
         style={{flex: 1}}

--- a/js/router/SharedNavigator.js
+++ b/js/router/SharedNavigator.js
@@ -37,7 +37,6 @@ import ControlPanel from '../views/ControlPanel';
 import ProfilePage from '../views/ProfilePage';
 
 import { checkTimeTriggers } from '../api/Triggers';
-import { loadCachedFormDataById } from '../api/Forms';
 import { initializeNotifications } from '../api/Notifications';
 
 connectToParseServer(Settings.parse.serverUrl, Settings.parse.appId);

--- a/js/router/SharedNavigator.js
+++ b/js/router/SharedNavigator.js
@@ -7,7 +7,6 @@ import React, {
 } from 'react-native';
 
 import Drawer from 'react-native-drawer';
-import PushNotification from 'react-native-push-notification';
 
 import Settings from '../settings';
 
@@ -100,12 +99,6 @@ const SharedNavigator = React.createClass({
         });
       }
     });
-  },
-
-  componentDidMount() {
-    if (Platform.OS === 'ios') {
-      PushNotification.requestPermissions();
-    }
   },
 
   /* Methods */
@@ -271,9 +264,6 @@ const SharedNavigator = React.createClass({
             style={{flex: 1}}
             navigationBar={
               <Header
-                ref={(ref) => {
-                  this._header = ref;
-                }}
                 title={this.state.title}
                 openDrawer={this.openControlPanel} />
             }

--- a/js/views/ControlPanel.js
+++ b/js/views/ControlPanel.js
@@ -4,9 +4,11 @@ import React, {
   Text,
   Linking,
 } from 'react-native';
+import pubsub from 'pubsub-js';
 import Store from '../data/Store';
 import Styles from '../styles/Styles';
 import ControlPanelItem from '../components/ControlPanelItem';
+import { loadNotifications } from '../api/Notifications';
 import { version } from '../../package';
 
 export default React.createClass({
@@ -22,6 +24,11 @@ export default React.createClass({
     };
   },
 
+  componentDidMount() {
+    pubsub.subscribe('onNotification', () => {
+      this.updateNotifications();
+    });
+  },
 
   /* Methods */
   navigateToView(path, title) {

--- a/js/views/ControlPanel.js
+++ b/js/views/ControlPanel.js
@@ -4,6 +4,7 @@ import React, {
   Text,
   Linking,
 } from 'react-native';
+import Store from '../data/Store';
 import Styles from '../styles/Styles';
 import ControlPanelItem from '../components/ControlPanelItem';
 import { version } from '../../package';
@@ -15,12 +16,28 @@ export default React.createClass({
     this.nextTitle = '';
   },
 
+  getInitialState() {
+    return {
+      notificationCount: Store.newNotifications,
+    };
+  },
+
+
+  /* Methods */
   navigateToView(path, title) {
     this.navigating = true;
     this.nextPath = path;
     this.nextTitle = title;
-    // this.props.changeRoute()
     this.props.closeDrawer();
+  },
+
+  navigateToNotificationsView() {
+    Store.newNotifications = 0;
+    this.setState({
+      notificationCount: 0,
+    }, () => {
+      this.navigateToView('notifications', 'Notifications');
+    });
   },
 
   handleLogout() {
@@ -40,8 +57,17 @@ export default React.createClass({
     );
   },
 
-  render() {
+  updateNotifications() {
+    const notifications = loadNotifications();
+    let count = notifications.length;
+    if (count > 99) {
+      count = 99;
+    }
+    this.setState({notificationCount: count});
+  },
 
+  /* Render */
+  render() {
     return (
       <View style={Styles.controlPanel.container}>
         <View style={Styles.controlPanel.itemList}>
@@ -50,8 +76,9 @@ export default React.createClass({
             text='Surveys'
           />
           <ControlPanelItem
-            onPress={() => this.navigateToView('notifications', 'Notifications')}
+            onPress={this.navigateToNotificationsView}
             text='Notifications'
+            counter={this.state.notificationCount}
           />
           <ControlPanelItem
             onPress={() => this.navigateToView('profile', 'Profile')}

--- a/js/views/NotificationsPage.js
+++ b/js/views/NotificationsPage.js
@@ -1,4 +1,5 @@
 import React, {
+  Alert,
   View,
   ListView,
 } from 'react-native';
@@ -13,7 +14,8 @@ const NotificationsPage = React.createClass({
   title: 'Notifications',
 
   getInitialState() {
-    const pendingNotifications = loadNotifications();
+    let pendingNotifications = loadNotifications();
+    pendingNotifications = [...pendingNotifications, ...pendingNotifications, ...pendingNotifications, ...pendingNotifications, ...pendingNotifications]
     const dataSource = new ListView.DataSource({
       rowHasChanged: (row1, row2) => row1 !== row2,
     });
@@ -64,13 +66,18 @@ const NotificationsPage = React.createClass({
   },
 
   handleClear() {
-    const currentNotifications = this.state.list;
-    this.setState({
-      list: [],
-      dataSource: this.state.dataSource.cloneWithRows([]),
-    }, () => {
-      clearNotifications(currentNotifications);
-    });
+    Alert.alert('Confirm', 'Are you sure you would like to clear ALL notifications?', [
+      {text: 'Cancel', onPress: () => { }, style: 'cancel' },
+      {text: 'OK', onPress: () => {
+        const currentNotifications = this.state.list;
+        this.setState({
+          list: [],
+          dataSource: this.state.dataSource.cloneWithRows([]),
+        }, () => {
+          clearNotifications(currentNotifications);
+        });
+      }},
+    ]);
   },
 
   /* Render */
@@ -83,12 +90,19 @@ const NotificationsPage = React.createClass({
   render() {
     return (
       <View style={[Styles.container.default, {flex: 1}]}>
-        <ListView dataSource = { this.state.dataSource }
-          renderRow = { this.renderItem }
-          contentContainerStyle = { [Styles.container.default, Styles.survey.list, {flex: 0}] }
-          enableEmptySections
-        />
-        <Button action={this.handleClear}>Clear</Button>
+        <View style={{flex: 1, paddingBottom: 60}}>
+          <ListView dataSource = { this.state.dataSource }
+            renderRow = { this.renderItem }
+            contentContainerStyle = { [Styles.container.default, Styles.survey.list, {flex: 0}] }
+            enableEmptySections
+          />
+        </View>
+        <Button
+          action={this.handleClear}
+          style={Styles.form.footerButton}
+          textStyle={[Styles.form.registerText, Styles.form.registerTextActive]}>
+          Clear
+        </Button>
       </View>
     );
   },

--- a/js/views/NotificationsPage.js
+++ b/js/views/NotificationsPage.js
@@ -14,8 +14,7 @@ const NotificationsPage = React.createClass({
   title: 'Notifications',
 
   getInitialState() {
-    let pendingNotifications = loadNotifications();
-    pendingNotifications = [...pendingNotifications, ...pendingNotifications, ...pendingNotifications, ...pendingNotifications, ...pendingNotifications]
+    const pendingNotifications = loadNotifications();
     const dataSource = new ListView.DataSource({
       rowHasChanged: (row1, row2) => row1 !== row2,
     });

--- a/js/views/NotificationsPage.js
+++ b/js/views/NotificationsPage.js
@@ -4,8 +4,9 @@ import React, {
 } from 'react-native';
 
 import Styles from '../styles/Styles';
-import { loadNotifications } from '../api/Notifications';
+import { loadNotifications, markNotificationsAsViewed, clearNotifications } from '../api/Notifications';
 import { loadCachedFormDataById } from '../api/Forms';
+import Button from '../components/Button';
 import Notification from '../components/Notification';
 
 const NotificationsPage = React.createClass({
@@ -23,7 +24,7 @@ const NotificationsPage = React.createClass({
   },
 
   componentDidMount() {
-    // this.loadList()
+    markNotificationsAsViewed(this.state.list);
   },
 
   componentWillUnmount() {
@@ -62,6 +63,16 @@ const NotificationsPage = React.createClass({
     });
   },
 
+  handleClear() {
+    const currentNotifications = this.state.list;
+    this.setState({
+      list: [],
+      dataSource: this.state.dataSource.cloneWithRows([]),
+    }, () => {
+      clearNotifications(currentNotifications);
+    });
+  },
+
   /* Render */
   renderItem(item) {
     return (
@@ -77,6 +88,7 @@ const NotificationsPage = React.createClass({
           contentContainerStyle = { [Styles.container.default, Styles.survey.list, {flex: 0}] }
           enableEmptySections
         />
+        <Button action={this.handleClear}>Clear</Button>
       </View>
     );
   },

--- a/js/views/NotificationsPage.js
+++ b/js/views/NotificationsPage.js
@@ -5,7 +5,7 @@ import React, {
 } from 'react-native';
 
 import Styles from '../styles/Styles';
-import { loadNotifications, markNotificationsAsViewed, clearNotifications } from '../api/Notifications';
+import { loadNotifications, markNotificationsAsViewed, clearNotifications, clearNotification } from '../api/Notifications';
 import { loadCachedFormDataById } from '../api/Forms';
 import Button from '../components/Button';
 import Notification from '../components/Notification';
@@ -56,6 +56,8 @@ const NotificationsPage = React.createClass({
     if (typeof data === 'undefined' || typeof data.survey === 'undefined' || typeof data.form === 'undefined') {
       return;
     }
+
+    clearNotification(notification);
     this.props.navigator.push({
       path: 'form',
       title: data.survey.title,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-native": "0.25.1",
     "react-native-checkbox": "https://github.com/dan-nyanko/react-native-checkbox#master",
     "react-native-drawer": "2.2.2",
-    "react-native-push-notification": "1.0.7",
+    "react-native-push-notification": "1.0.8",
     "react-native-vector-icons": "1.3.4",
     "realm": "0.13.2"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-native": "0.25.1",
     "react-native-checkbox": "https://github.com/dan-nyanko/react-native-checkbox#master",
     "react-native-drawer": "2.2.2",
-    "react-native-push-notification": "1.0.8",
+    "react-native-push-notification": "1.0.7",
     "react-native-vector-icons": "1.3.4",
     "realm": "0.14.1"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-native-drawer": "2.2.2",
     "react-native-push-notification": "1.0.8",
     "react-native-vector-icons": "1.3.4",
-    "realm": "0.13.2"
+    "realm": "0.14.1"
   },
   "devDependencies": {
     "babel-cli": "6.10.1",


### PR DESCRIPTION
Stories:
https://www.pivotaltracker.com/story/show/126404897
https://www.pivotaltracker.com/story/show/121941821
https://www.pivotaltracker.com/story/show/127087783

Changes:
- Moves most of the notification logic to `api/Notifications.js` to avoid bloating the `SharedNavigator` component.
- Adds discrete UI notices for when notifications are received on the foreground.
- Adds a menu counter for new notifications.
- Adds option to quickly clear in-app notifications.
- Properly delete notifications when selected in `NotificationsPage`.
- Changes unique ids on Notification objects to match the ones received by Push. (Local notifications still keep their formIDs as their primary key)

Bug fixes:
- Updates realm.io and limits some of the usage in the background to avoid a crash caused when new push notifications were received. (Android)
