### PR TITLE
Adds support for active/expired surveys

### DIFF
--- a/js/api/Surveys.js
+++ b/js/api/Surveys.js
@@ -98,6 +98,7 @@ export function cacheParseSurveys(survey) {
         description: survey.get('description'),
         user: 'Test University',
         forms: [],
+        expired: survey.get('deleted'),
       }, true);
       getSurveyOwner(survey);
     });

--- a/js/components/SurveyListFilter.js
+++ b/js/components/SurveyListFilter.js
@@ -80,7 +80,7 @@ const SurveyListFilterButton = React.createClass({
   },
   render() {
     const buttonContainerStyle = {opacity: 0.5};
-    let buttonViewStyle = {flex: 1, paddingHorizontal: 20, paddingVertical: 16, justifyContent: 'center', alignItems: 'center'};
+    let buttonViewStyle = {flex: 1, paddingHorizontal: 12, paddingVertical: 16, justifyContent: 'center', alignItems: 'center'};
     if (this.props.active) {
       buttonContainerStyle.opacity = 1;
     }

--- a/js/components/SurveyListFilter.js
+++ b/js/components/SurveyListFilter.js
@@ -60,6 +60,13 @@ const SurveyListFilter = React.createClass({
           >
           Declined
         </SurveyListFilterButton>
+        <SurveyListFilterButton
+          active={this.state.activeButton === 'expired'}
+          onPress={this.handlePress.bind(this, 'expired')}
+          icon='stop-circle-o'
+          >
+          Expired
+        </SurveyListFilterButton>
       </View>
     );
   },

--- a/js/data/Realm.js
+++ b/js/data/Realm.js
@@ -11,7 +11,7 @@ import TimeTrigger from '../models/TimeTrigger';
 import Test from '../models/Test';
 
 const realmInstance = new Realm({
-  schemaVersion: 43,
+  schemaVersion: 45,
   schema: [
     Survey,
     Form,

--- a/js/data/Realm.js
+++ b/js/data/Realm.js
@@ -11,7 +11,7 @@ import TimeTrigger from '../models/TimeTrigger';
 import Test from '../models/Test';
 
 const realmInstance = new Realm({
-  schemaVersion: 45,
+  schemaVersion: 48,
   schema: [
     Survey,
     Form,
@@ -32,7 +32,7 @@ const realmInstance = new Realm({
 export function clearRealmCache(objectName, idExclusions) {
   try {
     const objects = realmInstance.objects(objectName);
-    const expiredSurveys = [];
+    const expiredItems = [];
     const excludedIds = [];
     for (let i = 0; i < idExclusions.length; i++) {
       excludedIds.push(idExclusions[i].id);
@@ -48,12 +48,12 @@ export function clearRealmCache(objectName, idExclusions) {
         }
       }
       if (expired) {
-        expiredSurveys.push(objects[i]);
+        expiredItems.push(objects[i]);
       }
     }
 
     realmInstance.write(() => {
-      realmInstance.delete(expiredSurveys);
+      realmInstance.delete(expiredItems);
     });
   } catch (e) {
     console.error(e);

--- a/js/models/Survey.js
+++ b/js/models/Survey.js
@@ -17,6 +17,5 @@ Survey.schema = {
     user: 'string',
     title: 'string',
     description: 'string',
-    expired: 'bool',
   },
 };

--- a/js/models/Survey.js
+++ b/js/models/Survey.js
@@ -17,5 +17,6 @@ Survey.schema = {
     user: 'string',
     title: 'string',
     description: 'string',
+    expired: 'bool',
   },
 };

--- a/js/views/SurveyListPage.js
+++ b/js/views/SurveyListPage.js
@@ -112,11 +112,27 @@ const SurveyListPage = React.createClass({
 
   filterList(query) {
     let filteredList = [];
+    const isExpired = query === 'expired';
 
     // Filter the survey by category
     if (query === 'all') {
-      filteredList = this._surveys.slice();
+      // Return all active surveys
+      filteredList = _.filter(this._surveys, (survey) => {
+        return !survey.expired;
+      });
+    } else if (query === 'expired') {
+      // Return accepted surveys that have been deactivated
+      const invitations = _.filter(this._invitations, (invitation) => {
+        return invitation.status === 'accepted';
+      });
+      const surveyIds = _.map(invitations, (invitation) => {
+        return invitation.surveyId;
+      });
+      filteredList = _.filter(this._surveys, (survey) => {
+        return surveyIds.indexOf(survey.id) >= 0 && survey.expired;
+      });
     } else {
+      // Returns active surveys filtered by their status
       const invitations = _.filter(this._invitations, (invitation) => {
         return invitation.status === query;
       });
@@ -124,7 +140,7 @@ const SurveyListPage = React.createClass({
         return invitation.surveyId;
       });
       filteredList = _.filter(this._surveys, (survey) => {
-        return surveyIds.indexOf(survey.id) >= 0;
+        return surveyIds.indexOf(survey.id) >= 0 && !survey.expired;
       });
     }
 


### PR DESCRIPTION
Story:
https://www.pivotaltracker.com/story/show/126138113

Changes:
- Adds a tab for expired surveys
- Adds a method for refreshing only the expired survey list
- Refactors pruning of deleted surveys.
- Refactors Survey fetching to prevent data from going missing as the number of Surveys increases in the backend.
  - Our Parse fetching was still acquiring data in full chunks, never taking advantage of the local cache. It would also fetch surveys marked as 'deleted'. This could potentially cause many problems as new surveys keep being added to the server.
